### PR TITLE
[Feature] Logging to Google Stackdriver

### DIFF
--- a/config/main.php
+++ b/config/main.php
@@ -18,6 +18,7 @@ return [
             'class' => 'i8\modules\v1\ApiModule'
         ]
     ],
+    'bootstrap' => ['log'],
     'components' => [
         'db' => $db,
         'user' => [
@@ -53,6 +54,15 @@ return [
                     'encodeOptions' => JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
                 ]
             ]
+        ],
+        'log' => [
+            'traceLevel' => YII_DEBUG ? 3 : 0,
+            'targets' => [
+                [
+                    'class' => 'yii\log\SyslogTarget',
+                    'levels' => ['error', 'warning'],
+                ],
+            ],
         ],
         'cache' => [
             'class' => 'yii\caching\MemCache',


### PR DESCRIPTION
As mentioned here: 

https://cloud.google.com/appengine/docs/standard/php/logs/

App Engine offers free of charge logging to Stackdriver for up to 7 days and 5GB. To make use of it, the app should use [syslog()](http://php.net/manual/en/function.syslog.php) when writing logs. Fortunately for us Yii2 already have a dedicated target class using that PHP function. So this PR should be enough to enable proper logging in google cloud.

Feel free to not merge it if you disagree and thank you for sharing the template.